### PR TITLE
과제 수정

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -94,6 +94,7 @@ header .inner .add-more {
   top: 50px;
   right: 70px;
   display: none;
+  z-index: 1;
 }
 header .inner .add-more:after {
   border-top: 0 solid #24292f;
@@ -123,6 +124,7 @@ header .inner .profile-more {
   right: 20px;
   width: 150px;
   display: none;
+  z-index: 1;
 }
 header .inner .profile-more:after {
   border-top: 0 solid #24292f;
@@ -207,6 +209,7 @@ main aside {
   max-width: 500px;
   height: 100vh;
   position: sticky;
+  top: 0;
   background-color: #fff;
 }
 main aside .inner {
@@ -914,24 +917,24 @@ main .center-content .main-content .inner .tips p {
 main .center-content .main-content .inner .tips p span {
   font-size: 12px;
 }
-main .center-content .main-content .inner footer {
+main .center-content .main-content .inner .footer {
   display: flex;
   color: #57606A;
   font-size: 12px;
 }
-main .center-content .main-content .inner footer .logo {
+main .center-content .main-content .inner .footer .logo {
   margin-right: 118px;
 }
-main .center-content .main-content .inner footer .logo img {
+main .center-content .main-content .inner .footer .logo img {
   width: 24px;
   margin-right: 8px;
 }
-main .center-content .main-content .inner footer .links {
+main .center-content .main-content .inner .footer .links {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-column-gap: 50px;
 }
-main .center-content .main-content .inner footer .links ul li a {
+main .center-content .main-content .inner .footer .links ul li a {
   line-height: 1.5;
 }
 main .changes {

--- a/index.html
+++ b/index.html
@@ -494,7 +494,7 @@
               <a href="#">Subscribe to your news feed</a>
             </p>
           </div>
-          <footer>
+          <div class='footer'>
             <div class="logo">
               <img src="images/footer-logo.png" alt="">
               <a href="#">&copy; 2022 GitHub, Inc.</a>
@@ -520,7 +520,7 @@
                 <li><a href="#">Docs</a></li>
               </ul>
             </div>
-          </footer>
+          </div>
         </div>
       </div>
     </section>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@ headerSearch.addEventListener("click", () => {
 //header submenu plus button 더보기
 const addMore = document.querySelector(".add-more");
 const addBtn = document.querySelectorAll(".add-btn");
+
 addBtn[0].addEventListener("click", () => {
   addMore.classList.toggle("show");
 });
@@ -15,10 +16,46 @@ addBtn[1].addEventListener("click", () => {
   addMore.classList.toggle("show");
 });
 
+//멘토님 피드백 반영하여 수정한 부분
+
+//전체 영역을 클릭할 경우 창이 닫히도록 구현하고 싶어서 window.addEventListener를 사용했는데 구현이 안됐습니다 .. 대신 body 영역이 header와 main으로만 구성되어 있어 이 둘을 따로따로 불러왔습니다.
+const header = document.querySelector("header");
+const main = document.querySelector("main");
+
+/* 버블링현상 때문인지 header에서는 addMore.classList.remove이 먼저 적용되어 토글효과까지 사라집니다. e.stopPropagation();를 적용했는데도 문제가 해결되지 않아 주석처리 했습니다
+
+header.addEventListener("click", (e) => {
+  e.stopPropagation();
+  if (addMore.classList.contains("show")) {
+    addMore.classList.remove("show");
+  }
+}); */
+
+main.addEventListener("click", (e) => {
+  if (addMore.classList.contains("show")) {
+    addMore.classList.remove("show");
+  }
+});
+
 //header submenu profile image 더보기
 const profileMore = document.querySelector(".profile-more");
 addBtn[2].addEventListener("click", () => {
   profileMore.classList.toggle("show");
+});
+
+//멘토님 피드백 반영하여 수정한 부분
+
+/* add-more와 마찬가지로 header에서는 적용이 안되어 주석처리 했습니다.
+  header.addEventListener("click", (e) => {
+  if (profileMore.classList.contains("show")) {
+    profileMore.classList.remove("show");
+  }
+}); */
+
+main.addEventListener("click", (e) => {
+  if (profileMore.classList.contains("show")) {
+    profileMore.classList.remove("show");
+  }
 });
 
 //main-side section user 더보기
@@ -34,6 +71,19 @@ closeBtn.addEventListener("click", () => {
   userMore.style.display = "none";
 });
 
+//멘토님 피드백 반영하여 수정한 부분
+header.addEventListener("click", () => {
+  if (userMore.classList.contains("show")) {
+    userMore.classList.remove("show");
+  }
+});
+/* 위의 경우와 유사하게 main에 영역에서는 실행되지 않아 주석처리하였습니다
+  main.addEventListener("click", () => {
+  if (userMore.classList.contains("show")) {
+    userMore.classList.remove("show");
+  }
+}); */
+
 //main-center section에서 이미지 영역 클릭시 유투브 페이지 이동
 const imgContainer = document.querySelector(".img-container");
 imgContainer.onclick = () => {
@@ -44,6 +94,7 @@ imgContainer.onclick = () => {
 const tabList = document.querySelectorAll(".select-list");
 tabList.forEach((list) => {
   list.addEventListener("click", (e) => {
+    e.preventDefault();
     const tabContent = document.querySelectorAll(".tab-content");
     let tabNum = e.currentTarget.getAttribute("data-tabnum");
     tabContent.forEach((contentele, index) => {


### PR DESCRIPTION
# 📍 GitHub 사이트 클론코딩 수정

##  🗒 피드백을 받았지만 해결하지 못 한 부분
1. header의 ul class="sub-menu"에 있는 li들을 클릭하면 나오는 세부 정보는 toggle로 구현하여 해당 요소를 다시 클릭할 경우에만 닫힙니다. 해당 요소가 아닌 페이지 아무 구역이나 클릭해도 닫힐 수 있도록 구현하고 싶습니다.

2. 1번과 마찬가지로 aside의 div class="user" 또한 세부 정보 더보기를 toggle로 구현했습니다. 해당 요소를 아무 구역이나 클릭해도 닫힐 수 있도록 구현하고 싶습니다.

## ✂️ 멘토님 피드백과 수정하려 노력한 부분
정답을 제시하는 것보다는 공부해서 스스로 만들어보는게 의미가 있을 것 같아 남깁니다.
1. main 어떤 곳을 클릭해도 user-more에 show 클래스가 있는지 확인하고 있으면 삭제한다.
↳ main뿐 아니라 header를 포함한 전체 영역을 클릭했을 시 창이 닫히도록 구현하고 싶었습니다. window.addEventlister로 전체 영역에 적용하려 해봤지만 작동하지 않아 header와 main을 따로 따로 불러왔습니다. 
2. 단, user-more을 클릭하면 클릭 이벤트가 main에 도달하지 않는다.
↳ e.stopPropagation();를 적용해 이벤트가 부모요소까지 올라가지 않도록 했는데 먹히지 않았어요 ..
3. closeBtn은 클릭했을 때 show 클래스를 삭제할 수 있다.
↳ addMore.classList.remove("show”)를 통해 클래스를 삭제했습니다.
